### PR TITLE
Prevent someone from accidentally publishing this package

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: tiler_example
 version: 1.0.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.2.1-dev.2.0 <3.0.0"


### PR DESCRIPTION
The analyzer catches this these days, and I'd like to roll the flutter/tests registry to the latest version... so this is blocking me. :-)