### PR TITLE
Comment out the "author" line

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: tiler
 version: 0.1.4
 description: Library for rendering maps created with the Tiled map editor in Dart/Flutter.
-author: Danny Tuppeny <danny@tuppeny.com>
+# author: Danny Tuppeny <danny@tuppeny.com>
 repository: https://github.com/DanTup/tiler
 
 environment:


### PR DESCRIPTION
The Dart analyzer these days reports `warning • The 'author' field is no longer used and can be removed • pubspec.yaml:4:1 • deprecated_field`.
I could also just turn off that warning in the analysis options if you prefer.